### PR TITLE
Add Regimen Fiscal Receptor if available

### DIFF
--- a/templates/generic.php
+++ b/templates/generic.php
@@ -152,6 +152,9 @@ $pagoCount = $pagos->count();
                 <?php if ('' !== $receptor['NumRegIdTrib']) : ?>
                     <br/>Residencia fiscal: <?=$this->e($receptor['NumRegIdTrib'])?>
                 <?php endif; ?>
+                <?php if ('' !== $receptor['RegimenFiscalReceptor']) : ?>
+                    <br/>Régimen Fiscal: <?=$this->e($receptor['RegimenFiscalReceptor'])?>
+                <?php endif; ?>
             </p>
         </div>
     </div>


### PR DESCRIPTION
* CFDI 4.0 requires `RegimenFiscalReceptor`, adds it to the PDF if available.

![image](https://user-images.githubusercontent.com/780497/190939099-7ff476c7-4338-4e04-ab21-baeadbc1af91.png)

Note: Was going to push code to add Pagos 2.0 support before realizing that PR #15 already includes those changes along with better CFDI 4.0 support and this change as well, happy to collaborate to close this PR get that one merged instead.