### PR TITLE
Maintenance 2023-06-07 (v0.4.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -130,7 +130,7 @@ jobs:
           fi
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           php-version: '8.1'
           coverage: none
           tools: composer:v2, phpstan
-          extensions: soap
+          extensions: soap, gd
         env:
           fail-fast: true
       - name: Get composer cache directory
@@ -114,7 +114,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           coverage: xdebug
           tools: composer:v2
-          extensions: soap
+          extensions: soap, gd
         env:
           fail-fast: true
       - name: Install SAT XML resources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "master" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer-normalize
         env:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -73,7 +73,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
           extensions: soap, gd
@@ -142,6 +142,7 @@ jobs:
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose --coverage-clover=build/coverage-clover.xml
       - name: Upload code coverage to scrutinizer
+        if: ${{ !env.ACT }} # do not run if using nektos/act
         uses: sudo-bot/action-scrutinizer@latest
         with:
           cli-args: "--format=php-clover build/coverage-clover.xml"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           php-version: '7.3' # use minimal version
           coverage: none
           tools: composer:v2
-          extensions: soap
+          extensions: soap, gd
         env:
           fail-fast: true
       - name: "Get composer cache directory"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           fail-fast: true
       - name: "Get composer cache directory"
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: "Cache dependencies"
         uses: actions/cache@v3
         with:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="composer-normalize" version="^2.28.3" installed="2.28.3" location="./tools/composer-normalize" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.11.0" installed="3.11.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.8.5" installed="1.8.5" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.31.0" installed="2.31.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.17.0" installed="3.17.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.16" installed="1.10.16" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,7 +18,7 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         // basic
-        'braces' => false, // do not let php-cs-fixer fix this, causes problem with php close tag
+        'statement_indentation' => false, // invalid indentation
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
@@ -26,12 +26,15 @@ return (new PhpCsFixer\Config())
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'arguments']],
+        'new_with_braces' => true,
+        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
         'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
+        'single_blank_line_before_namespace' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,9 +7,7 @@ filter:
 build:
   dependencies:
     override:
-      - composer self-update --no-interaction --no-progress
-      - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan phpunit/phpunit --dev --no-interaction --no-progress --no-update
-      - composer install --no-interaction
+      - composer update --no-interaction
   nodes:
     php:
       tests:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 - 2020 PHPCFDI
+Copyright (c) 2018 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/phpcfdi/cfditopdf?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/cfditopdf?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/cfditopdf?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/cfditopdf/build/master?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/cfditopdf/build.yml?branch=master&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/cfditopdf/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/cfditopdf/master?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/cfditopdf?style=flat-square

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ This update fixes the continuous integration process and ensures compatibility w
   - Require extension `gd`.
   - Add PHP 8.2 to test matrix.
   - Run jobs using PHP 8.2.
+  - Allow run `build.yml` on demand.
   - Remove obsolete commands on Scrutinizer-CI.
 - Update development tools.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ This update fixes the continuous integration process and ensures compatibility w
 
 - Introduce `CastToStringTrait#strval()` to avoid PHPStan issues.
 - Update `php-cs-fixer` configuration file.
+- Update license year.
 
 ## Version 0.4.0 2022-09-22 - Viva México
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ This update fixes the continuous integration process and ensures compatibility w
 - Introduce `CastToStringTrait#strval()` to avoid PHPStan issues.
 - Update `php-cs-fixer` configuration file.
 - Update license year.
+- Fix build badge.
 
 ## Version 0.4.0 2022-09-22 - Viva México
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ This update fixes the continuous integration process and ensures compatibility w
 - Update `php-cs-fixer` configuration file.
 - Update license year.
 - Fix build badge.
+- On GitHub workflows:
+  - Replace GitHub directive `::set-output` to `$GITHUB_OUTPUT`.
 - Update development tools.
 
 ## Version 0.4.0 2022-09-22 - Viva México

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 This update fixes the continuous integration process and ensures compatibility with PHP 8.2.
 
 - Introduce `CastToStringTrait#strval()` to avoid PHPStan issues.
+- Update `php-cs-fixer` configuration file.
 
 ## Version 0.4.0 2022-09-22 - Viva México
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `phpcfdi/cfditopdf` Changelog
 
+## Version 0.4.1 2023-06-07
+
+This update fixes the continuous integration process and ensures compatibility with PHP 8.2.
+
+- Introduce `CastToStringTrait#strval()` to avoid PHPStan issues.
+
 ## Version 0.4.0 2022-09-22 - Viva México
 
 - Bump PHP Version to 7.3.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ This update fixes the continuous integration process and ensures compatibility w
   - Replace GitHub directive `::set-output` to `$GITHUB_OUTPUT`.
   - Require extension `gd`.
   - Add PHP 8.2 to test matrix.
+  - Run jobs using PHP 8.2.
 - Update development tools.
 
 ## Version 0.4.0 2022-09-22 - Viva México

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ This update fixes the continuous integration process and ensures compatibility w
 - Update `php-cs-fixer` configuration file.
 - Update license year.
 - Fix build badge.
+- Update development tools.
 
 ## Version 0.4.0 2022-09-22 - Viva México
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ This update fixes the continuous integration process and ensures compatibility w
   - Require extension `gd`.
   - Add PHP 8.2 to test matrix.
   - Run jobs using PHP 8.2.
+  - Remove obsolete commands on Scrutinizer-CI.
 - Update development tools.
 
 ## Version 0.4.0 2022-09-22 - Viva México

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ This update fixes the continuous integration process and ensures compatibility w
 - Fix build badge.
 - On GitHub workflows:
   - Replace GitHub directive `::set-output` to `$GITHUB_OUTPUT`.
+  - Require extension `gd`.
 - Update development tools.
 
 ## Version 0.4.0 2022-09-22 - Viva México

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ This update fixes the continuous integration process and ensures compatibility w
 - On GitHub workflows:
   - Replace GitHub directive `::set-output` to `$GITHUB_OUTPUT`.
   - Require extension `gd`.
+  - Add PHP 8.2 to test matrix.
 - Update development tools.
 
 ## Version 0.4.0 2022-09-22 - Viva México

--- a/src/CfdiDataBuilder.php
+++ b/src/CfdiDataBuilder.php
@@ -11,9 +11,12 @@ use CfdiUtils\Nodes\NodeInterface;
 use CfdiUtils\Nodes\XmlNodeUtils;
 use CfdiUtils\TimbreFiscalDigital\TfdCadenaDeOrigen;
 use CfdiUtils\XmlResolver\XmlResolver;
+use PhpCfdi\CfdiToPdf\Internal\CastToStringTrait;
 
 class CfdiDataBuilder
 {
+    use CastToStringTrait;
+
     /** @var XmlResolver */
     private $xmlResolver;
 
@@ -72,7 +75,10 @@ class CfdiDataBuilder
             return '';
         }
         $tfdCadenaOrigen = new TfdCadenaDeOrigen($this->xmlResolver(), $this->xsltBuilder());
-        return $tfdCadenaOrigen->build(XmlNodeUtils::nodeToXmlString($tfd), strval($tfd['Version'] ?: $tfd['version']));
+        return $tfdCadenaOrigen->build(
+            XmlNodeUtils::nodeToXmlString($tfd),
+            $this->strval($tfd['Version'] ?: $tfd['version']),
+        );
     }
 
     /**
@@ -82,12 +88,12 @@ class CfdiDataBuilder
     public function createQrUrl(NodeInterface $comprobante): string
     {
         $parameters = new RequestParameters(
-            strval($comprobante['Version']),
+            $this->strval($comprobante['Version']),
             $comprobante->searchAttribute('cfdi:Emisor', 'Rfc'),
             $comprobante->searchAttribute('cfdi:Receptor', 'Rfc'),
-            strval($comprobante['Total']),
+            $this->strval($comprobante['Total']),
             $comprobante->searchAttribute('cfdi:Complemento', 'tfd:TimbreFiscalDigital', 'UUID'),
-            strval($comprobante['Sello']),
+            $this->strval($comprobante['Sello']),
         );
         return $parameters->expression();
     }

--- a/src/Internal/CastToStringTrait.php
+++ b/src/Internal/CastToStringTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiToPdf\Internal;
+
+use Stringable;
+
+/**
+ * @internal
+ */
+trait CastToStringTrait
+{
+    /** @param mixed $value */
+    private function strval($value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (null === $value || is_scalar($value) || (is_object($value) && is_callable([$value, '__toString']))) {
+            /** @phpstan-var null|scalar|Stringable $value */
+            return strval($value);
+        }
+        return '';
+    }
+}

--- a/tests/Integration/ConverterTest.php
+++ b/tests/Integration/ConverterTest.php
@@ -9,6 +9,7 @@ use CfdiUtils\Cleaner\Cleaner;
 use PhpCfdi\CfdiToPdf\Builders\Html2PdfBuilder;
 use PhpCfdi\CfdiToPdf\CfdiDataBuilder;
 use PhpCfdi\CfdiToPdf\Converter;
+use PhpCfdi\CfdiToPdf\Internal\CastToStringTrait;
 use PhpCfdi\CfdiToPdf\Tests\PdfToText\PdfToText;
 use PhpCfdi\CfdiToPdf\Tests\TestCase;
 
@@ -17,6 +18,8 @@ use PhpCfdi\CfdiToPdf\Tests\TestCase;
  */
 class ConverterTest extends TestCase
 {
+    use CastToStringTrait;
+
     /** @var PdfToText */
     private $pdfToText;
 
@@ -36,7 +39,7 @@ class ConverterTest extends TestCase
         $cfdiData = (new CfdiDataBuilder())
             ->withXmlResolver($this->createXmlResolver())
             ->build($cfdi->getNode());
-        $uuid = strval($cfdiData->timbreFiscalDigital()['UUID']);
+        $uuid = $this->strval($cfdiData->timbreFiscalDigital()['UUID']);
 
         $builder = new Html2PdfBuilder();
         $converter = new Converter($builder);
@@ -81,16 +84,16 @@ class ConverterTest extends TestCase
         $this->assertFileExists($created);
 
         $contents = $this->pdfToText->extract($created);
-        $this->assertStringContainsString(strval($doctoRelacionado['IdDocumento']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['Serie']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['Folio']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['MonedaDR']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['TipoCambioDR']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['MetodoDePagoDR']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['NumParcialidad']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['ImpPagado']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['ImpSaldoInsoluto']), $contents);
-        $this->assertStringContainsString(strval($doctoRelacionado['ImpSaldoAnt']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['IdDocumento']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['Serie']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['Folio']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['MonedaDR']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['TipoCambioDR']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['MetodoDePagoDR']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['NumParcialidad']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['ImpPagado']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['ImpSaldoInsoluto']), $contents);
+        $this->assertStringContainsString($this->strval($doctoRelacionado['ImpSaldoAnt']), $contents);
         unlink($created);
     }
 }


### PR DESCRIPTION
This update fixes the continuous integration process and ensures compatibility with PHP 8.2.

- Introduce `CastToStringTrait#strval()` to avoid PHPStan issues.
- Update `php-cs-fixer` configuration file.
- Update license year.
- Fix build badge.
- On GitHub workflows:
  - Replace GitHub directive `::set-output` to `$GITHUB_OUTPUT`.
  - Require extension `gd`.
  - Add PHP 8.2 to test matrix.
  - Run jobs using PHP 8.2.
  - Allow run `build.yml` on demand.
  - Remove obsolete commands on Scrutinizer-CI.
- Update development tools.
