### PR TITLE
Make it compatible with PHP 8.4 (version 0.4.3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           fail-fast: true
       - name: Composer normalize
-        run: composer-normalize
+        run: composer-normalize --dry-run
 
   phpcs:
     name: Code style (phpcs)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
+          extensions: soap, gd
           coverage: none
           tools: composer:v2, phpstan
-          extensions: soap, gd
         env:
           fail-fast: true
       - name: Get composer cache directory
@@ -113,9 +113,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          extensions: soap, gd
           coverage: xdebug
           tools: composer:v2
-          extensions: soap, gd
         env:
           fail-fast: true
       - name: Install SAT XML resources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer-normalize
         env:
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -57,7 +57,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -74,7 +74,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2, phpstan
           extensions: soap, gd

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.3' # use minimal version
+          extensions: soap, gd
           coverage: none
           tools: composer:v2
-          extensions: soap, gd
         env:
           fail-fast: true
       - name: "Get composer cache directory"

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="composer-normalize" version="^2.43.0" installed="2.43.0" location="./tools/composer-normalize" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.64.2" installed="3.64.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.10.2" installed="3.10.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.10.2" installed="3.10.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.12.0" installed="1.12.0" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.89.2" installed="3.89.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.13.5" installed="3.13.5" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.13.5" installed="3.13.5" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.31" installed="2.1.31" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,8 +15,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
+        '@PHP7x1Migration:risky' => true,
+        '@PHP7x3Migration' => true,
         // basic
         'statement_indentation' => false, // invalid indentation
         // symfony

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,6 +6,11 @@ filter:
 # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
 build:
   dependencies:
+    before:
+      - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+      - php composer-setup.php --install-dir=$HOME/bin --filename=composer
+      - php -r "unlink('composer-setup.php');"
+      - $HOME/bin/composer --version
     override:
       - composer update --no-interaction
   nodes:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 - 2024 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2018 - 2025 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=7.3",
-        "eclipxe/cfdiutils": "^2.29",
+        "eclipxe/cfdiutils": "^2.29 || ^3.0",
         "league/plates": "^3.5",
         "phpcfdi/cfdi-cleaner": "^1.3.3",
         "spipu/html2pdf": "^5.2.8"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=7.3",
-        "eclipxe/cfdiutils": "^2.29 || ^3.0",
+        "eclipxe/cfdiutils": "^2.31 || ^3.0",
         "league/plates": "^3.5",
         "phpcfdi/cfdi-cleaner": "^1.3.3",
         "spipu/html2pdf": "^5.2.8"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # `phpcfdi/cfditopdf` Changelog
 
+## Version 0.4.3 2024-11-08
+
+- Fix compatibility with PHP 8.4.
+- Allow dependence of `eclipxe/cfdiutils` to match versions `^2.31` and `^3.0`.
+- Update license year to 2025.
+
+These changes apply to the development environment:
+
+- Update code standards for `phpcs` and `php-cs-fixer`.
+- Add PHP 8.4 to test matrix.
+- Run workflows jobs using PHP 8.4.
+- Fix workflow job `composer-normalize`. It didn't fail on `composer.json` errors.
+- Update development tools.
+
 ## Version 0.4.2 2024-09-02
 
 - Fix issue on CFDI 4.0 generate only the first block of information for `cfdi:CfdiRelacionados`.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,7 +21,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/src/Builders/Html2PdfBuilder.php
+++ b/src/Builders/Html2PdfBuilder.php
@@ -20,7 +20,7 @@ class Html2PdfBuilder implements BuilderInterface
      *
      * @param HtmlTranslatorInterface|null $htmlTranslator If NULL will use a generic translator
      */
-    public function __construct(HtmlTranslatorInterface $htmlTranslator = null)
+    public function __construct(?HtmlTranslatorInterface $htmlTranslator = null)
     {
         if (null === $htmlTranslator) {
             $htmlTranslator = new HtmlTranslators\PlatesHtmlTranslator(

--- a/src/Internal/CastToStringTrait.php
+++ b/src/Internal/CastToStringTrait.php
@@ -17,9 +17,12 @@ trait CastToStringTrait
         if (is_string($value)) {
             return $value;
         }
-        if (null === $value || is_scalar($value) || (is_object($value) && is_callable([$value, '__toString']))) {
-            /** @phpstan-var null|scalar|Stringable $value */
+        if (null === $value || is_scalar($value)) {
             return strval($value);
+        }
+        if (is_object($value) && is_callable([$value, '__toString'])) {
+            /** @phpstan-var Stringable $value */
+            return $value->__toString();
         }
         return '';
     }


### PR DESCRIPTION
- Fix compatibility with PHP 8.4.
- Allow dependence of `eclipxe/cfdiutils` to match versions `^2.31` and `^3.0`.
- Update license year to 2025.

These changes apply to the development environment:

- Update code standards for `phpcs` and `php-cs-fixer`.
- Add PHP 8.4 to test matrix.
- Run workflows jobs using PHP 8.4.
- Fix workflow job `composer-normalize`. It didn't fail on `composer.json` errors.
- Update development tools.
